### PR TITLE
Support lazy-loaded images and data: URIs

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -70,9 +70,9 @@ $(document).on('mouseenter', 'img', function() {
 				} else if (fileSizeBytes < 1024) {
 					updateBlock(fileSizeBytes + ' B');
 				} else if (fileSizeBytes / 1024 < 1024) {
-					updateBlock((fileSizeBytes / 1024).toFixed(2) + ' Kb');
+					updateBlock((fileSizeBytes / 1024).toFixed(2) + ' KiB');
 				} else {
-					updateBlock((fileSizeBytes / 1048576).toFixed(2) + ' Mb');
+					updateBlock((fileSizeBytes / 1048576).toFixed(2) + ' MiB');
 				}
 			}
 		});

--- a/js/content.js
+++ b/js/content.js
@@ -167,12 +167,12 @@ $(document.body).on('mouseover', 'img', function(e) {
 
 	updateBlock(image, null);
 
-	$(displayBlock).fadeIn(70);
+	displayBlock.fadeIn(70);
 });
 
 $(document.body).on('mouseout', 'img', function(e) {
 	if (isMetaKey(e)) {
 		return;
 	}
-	$(displayBlock).fadeOut(10);
+	displayBlock.fadeOut(10);
 });

--- a/js/content.js
+++ b/js/content.js
@@ -25,25 +25,26 @@ chrome.extension.sendRequest(optionsGet, function(response) {
 			displayBlock.css({
 				top: '1px',
 				left: '1px'
-			})
-			break
+			});
+			break;
 		case 'topRight':
 			displayBlock.css({
 				top: '1px',
 				right: '1px'
-			})
-			break
+			});
+			break;
 		case 'bottomLeft':
 			displayBlock.css({
 				bottom: '1px',
 				left: '1px'
-			})
-			break
+			});
+			break;
 		case 'bottomRight':
 			displayBlock.css({
 				bottom: '1px',
 				right: '1px'
-			})
+			});
+			break;
 	}
 });
 

--- a/js/content.js
+++ b/js/content.js
@@ -135,7 +135,7 @@ function updateBlock(image, byteCount) {
 	}
 }
 
-$(document).on('mouseenter', 'img', function() {
+$(document).on('mouseover', 'img', function() {
 	var image = this;
 	var imageSource = this.src;
 
@@ -154,7 +154,7 @@ $(document).on('mouseenter', 'img', function() {
 	$(displayBlock).fadeIn(70);
 });
 
-$(document).on('mouseleave', 'img', function(e) {
+$(document).on('mouseout', 'img', function(e) {
 	var isMetaKey = e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
 	if (isMetaKey) {
 		return;

--- a/js/content.js
+++ b/js/content.js
@@ -75,8 +75,7 @@ $(document).on('mouseenter', 'img', function() {
 					updateBlock((fileSizeBytes / 1048576).toFixed(2) + ' Mb');
 				}
 			}
-
-		});	
+		});
 	}
 
 	displayBlock.text(this.width + 'x' + this.height);

--- a/js/content.js
+++ b/js/content.js
@@ -4,10 +4,10 @@ var showFileSize = '';
 var displayBlockMarkup =
 	'<div id="ir-ext-ui">' +
 	'  <div class="ir-ext-dimensions">' +
-	'    <span class="ir-ext-rendered" title="Rendered image dimensions (after any scaling/resizing has been applied).">' +
+	'    <span class="ir-ext-rendered" title="Rendered image dimensions (after any scaling/resizing has been applied)">' +
 	'      <span data-ir-ext-width></span>x<span data-ir-ext-height></span>' +
 	'    </span>' +
-	'    <span class="ir-ext-natural" title="Natural image dimensions (without applying any scaling/resizing).">' +
+	'    <span class="ir-ext-natural" title="Natural image dimensions (without applying any scaling/resizing)">' +
 	'      (<span data-ir-ext-width></span>x<span data-ir-ext-height></span>)' +
 	'    </span>' +
 	'  </div>' +

--- a/js/content.js
+++ b/js/content.js
@@ -2,7 +2,7 @@ var options = [];
 var optionsGet = 'options';
 var showFileSize = '';
 var displayBlockMarkup =
-	'<div id="ir-ext-ui" dir="ltr">' +
+	'<div id="ir-ext-ui">' +
 	'  <div class="ir-ext-dimensions">' +
 	'    <span class="ir-ext-rendered" title="Rendered image dimensions (after any scaling/resizing has been applied).">' +
 	'      <span data-ir-ext-width></span>x<span data-ir-ext-height></span>' +

--- a/js/content.js
+++ b/js/content.js
@@ -135,7 +135,7 @@ function updateBlock(image, byteCount) {
 	}
 }
 
-$(document).on('mouseover', 'img', function() {
+$(document.body).on('mouseover', 'img', function() {
 	var image = this;
 	var imageSource = this.src;
 
@@ -154,7 +154,7 @@ $(document).on('mouseover', 'img', function() {
 	$(displayBlock).fadeIn(70);
 });
 
-$(document).on('mouseout', 'img', function(e) {
+$(document.body).on('mouseout', 'img', function(e) {
 	var isMetaKey = e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
 	if (isMetaKey) {
 		return;

--- a/js/content.js
+++ b/js/content.js
@@ -65,7 +65,9 @@ $(document).on('mouseenter', 'img', function() {
 					}
 				}
 
-				if (fileSizeBytes < 1024) {
+				if (fileSizeBytes == null) {
+					return;
+				} else if (fileSizeBytes < 1024) {
 					updateBlock(fileSizeBytes + ' B');
 				} else if (fileSizeBytes / 1024 < 1024) {
 					updateBlock((fileSizeBytes / 1024).toFixed(2) + ' Kb');

--- a/js/content.js
+++ b/js/content.js
@@ -66,6 +66,18 @@ chrome.extension.sendRequest(optionsGet, function(response) {
 	}
 });
 
+function isMetaKey(e) {
+	return e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
+}
+
+function isVisible(element) {
+	if (element.jquery) {
+		element = element[0];
+	}
+	var rect = element.getBoundingClientRect();
+	return rect.width > 0 && rect.height > 0;
+}
+
 function getByteCount(imageSource, jqXHR) {
 	var byteCount = jqXHR.getResponseHeader('Content-length');
 	var dataUriMatch = /^data:image\/[\w.+-]+(;base64)?,/.exec(imageSource);
@@ -135,7 +147,11 @@ function updateBlock(image, byteCount) {
 	}
 }
 
-$(document.body).on('mouseover', 'img', function() {
+$(document.body).on('mouseover', 'img', function(e) {
+	if (isMetaKey(e) && isVisible(displayBlock)) {
+		return;
+	}
+
 	var image = this;
 	var imageSource = this.src;
 
@@ -155,8 +171,7 @@ $(document.body).on('mouseover', 'img', function() {
 });
 
 $(document.body).on('mouseout', 'img', function(e) {
-	var isMetaKey = e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
-	if (isMetaKey) {
+	if (isMetaKey(e)) {
 		return;
 	}
 	$(displayBlock).fadeOut(10);

--- a/js/content.js
+++ b/js/content.js
@@ -66,6 +66,16 @@ chrome.extension.sendRequest(optionsGet, function(response) {
 	}
 });
 
+function getByteCount(imageSource, jqXHR) {
+	var byteCount = jqXHR.getResponseHeader('Content-length');
+	var dataUriMatch = /^data:image\/[\w.+-]+(;base64)?,/.exec(imageSource);
+	if (dataUriMatch) {
+		var dataUriContent = imageSource.substr(dataUriMatch[0].length);
+		byteCount = dataUriContent.length;
+	}
+	return byteCount;
+}
+
 function getFileSize(byteCount) {
 	var value;
 	var unit;
@@ -130,11 +140,11 @@ $(document).on('mouseenter', 'img', function() {
 	var imageSource = this.src;
 
 	if (showFileSize == 'on') {
-		var requestSize = $.ajax({
+		$.ajax({
 			type: 'HEAD',
 			url: imageSource,
-			success: function() {
-				updateBlock(image, requestSize.getResponseHeader('Content-length'));
+			success: function(data, textStatus, jqXHR) {
+				updateBlock(image, getByteCount(imageSource, jqXHR));
 			}
 		});
 	}

--- a/js/content.js
+++ b/js/content.js
@@ -13,7 +13,7 @@ var displayBlockMarkup =
 	'  </div>' +
 	'  <div class="ir-ext-filesize">' +
 	'    <span data-ir-ext-value></span>' +
-	'    <span data-ir-ext-unit></span>' +
+	'    <abbr data-ir-ext-unit></abbr>' +
 	'  </div>' +
 	'  <style>' +
 	'    #ir-ext-ui {' +
@@ -90,22 +90,27 @@ function getByteCount(imageSource, jqXHR) {
 
 function getFileSize(byteCount) {
 	var value;
-	var unit;
+	var unitName;
+	var unitTitle;
 
 	if (byteCount < 1024) {
 		value = byteCount;
-		unit = 'B';
+		unitName = 'B';
+		unitTitle = 'Byte'
 	} else if (byteCount / 1024 < 1024) {
 		value = (byteCount / 1024).toFixed(2);
-		unit = 'KiB';
+		unitName = 'KiB';
+		unitTitle = 'Kibibyte: 1 KiB = 2^10 (1024) bytes'
 	} else {
 		value = (byteCount / (1024 * 1024)).toFixed(2);
-		unit = 'MiB';
+		unitName = 'MiB';
+		unitTitle = 'Mebibyte: 1 MiB = 2^20 (1048576) bytes'
 	}
 
 	return {
 		value: value,
-		unit: unit
+		unitName: unitName,
+		unitTitle: unitTitle
 	};
 }
 
@@ -116,8 +121,12 @@ function updateDimensions(container, width, height) {
 
 function updateFileSize(container, byteCount) {
 	var fileSize = getFileSize(byteCount);
-	container.find('[data-ir-ext-value]').text(fileSize.value);
-	container.find('[data-ir-ext-unit]').text(fileSize.unit);
+	container.find('[data-ir-ext-value]')
+		.text(fileSize.value)
+		.attr('title', byteCount + ' bytes');
+	container.find('[data-ir-ext-unit]')
+		.text(fileSize.unitName)
+		.attr('title', fileSize.unitTitle);
 }
 
 function updateBlock(image, byteCount) {

--- a/js/content.js
+++ b/js/content.js
@@ -47,7 +47,7 @@ chrome.extension.sendRequest(optionsGet, function(response) {
 	}
 });
 
-$('img').on('mouseenter', function() {
+$(document).on('mouseenter', 'img', function() {
 	var image = this;
 	var imageSource = this.src;
 
@@ -84,6 +84,6 @@ $('img').on('mouseenter', function() {
 	$(displayBlock).fadeIn(70);
 });
 
-$('img').on('mouseleave', function() {
+$(document).on('mouseleave', 'img', function() {
 	$(displayBlock).fadeOut(10);
 });

--- a/js/content.js
+++ b/js/content.js
@@ -4,10 +4,10 @@ var showFileSize = '';
 var displayBlockMarkup =
 	'<div id="ir-ext-ui" dir="ltr">' +
 	'  <div class="ir-ext-dimensions">' +
-	'    <span class="ir-ext-rendered">' +
+	'    <span class="ir-ext-rendered" title="Rendered image dimensions (after any scaling/resizing has been applied).">' +
 	'      <span data-ir-ext-width></span>x<span data-ir-ext-height></span>' +
 	'    </span>' +
-	'    <span class="ir-ext-natural">' +
+	'    <span class="ir-ext-natural" title="Natural image dimensions (without applying any scaling/resizing).">' +
 	'      (<span data-ir-ext-width></span>x<span data-ir-ext-height></span>)' +
 	'    </span>' +
 	'  </div>' +

--- a/js/content.js
+++ b/js/content.js
@@ -7,7 +7,7 @@ var displayBlock = $('<div>').appendTo('body');
 		padding: '1px',
 		zIndex: '9999',
 		display: 'none',
-		fontFamily: 'Lucida Console',
+		fontFamily: 'Consolas, "Lucida Console", "Courier New", Courier, monospace',
 	});
 
 chrome.extension.sendRequest(optionsGet, function(response) {

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,6 @@
   "permissions": [
     "tabs",
     "http://*/*",
-    "https://*/*" 
+    "https://*/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "manifest_version": 2,
   "description": "Extension shows image size on hover in a minimalistic way",
-  "icos": {
+  "icons": {
   	"48": "icon48.png",
   	"128": "icon128.png"
   },


### PR DESCRIPTION
Contains the following enhancements:
- Support for lazy-loaded images (`<img>` elements added to the DOM after page load)
- Support for `data:` URIs (e.g., `<img src="data:image/png;base64,123...">`)
- Cross-platform monospace `font-family`
- Non-jerky image size update
- Allow user to lock on a particular image by pressing and holding one of the following keys while moving the mouse off of the image:
  - <kbd>Shift</kbd>
  - <kbd>Ctrl</kbd>
  - <kbd>Alt</kbd> (<kbd>Option ⌥</kbd> on Mac)
  - <kbd>Meta</kbd> (<kbd>Command ⌘</kbd> on Mac)
- Improved `Content-Length` detection
- Unambiguous binary prefixes for image sizes (e.g., `KiB` instead of `Kb`)
- Descriptive `title` attributes on overlay elements
- Updated manifest file syntax (`icos` => `icons`)
- A few minor code formatting improvements
